### PR TITLE
May have fixed a wallmask bug/possibally the custom maps bug?

### DIFF
--- a/Source/gg2/Scripts/CustomMaps/CustomMapProcessLevelData.gml
+++ b/Source/gg2/Scripts/CustomMaps/CustomMapProcessLevelData.gml
@@ -32,6 +32,9 @@
   screen_refresh()
   io_handle()
   // convert it to a sprite, and delete the surface
+  if(global.CustomMapCollisionSprite != -1) {
+    sprite_delete(global.CustomMapCollisionSprite); 	
+  } 
   var tempfile;
     tempfile = temp_directory + "/wallmask.png";
   if file_exists(tempfile) file_delete(tempfile);


### PR DESCRIPTION
Because of the problems with the deathcam script, it may be a good idea to save the wallmask data into an external file too, may /possibally/ fix the falling through floors issue anyways, seems to work fine, but I haven't hosted for long periods yet
