### PR TITLE
Double jump smoke

### DIFF
--- a/Source/gg2/Objects/InGameElements/Character.events/Begin Step.xml
+++ b/Source/gg2/Objects/InGameElements/Character.events/Begin Step.xml
@@ -68,6 +68,7 @@ if(!taunting and !omnomnomnom)
             playsound(x,y,JumpSnd);
             doublejumpUsed = 1;
             moveStatus = 0;
+            effect_create_below(ef_smoke,x-hspeed*1.3,y+vspeed*1.5,0,c_gray);
         }
     }
        


### PR DESCRIPTION
Edited Source/gg2/Objects/InGameElements/Character.events/Begin Step.xml via GitHub

Puff of smoke once Scout double jumps. To look nice.
