### PR TITLE
Adjusted DKotH stalemate conditions.

### DIFF
--- a/Source/gg2/Objects/Overlays/DKothHUD.events/Step.xml
+++ b/Source/gg2/Objects/Overlays/DKothHUD.events/Step.xml
@@ -13,16 +13,26 @@
       <not>false</not>
       <appliesTo>.self</appliesTo>
       <arguments>
-        <argument kind="STRING">//automatically change maps if the server is empty for too long
-//if (global.isHost and hostTimer &gt; 0 ) //and  //(!(!KothRedControlPoint.locked and KothRedControlPoint.capping == 0 and KothRedControlPoint.bluePresence == 0 and KothRedControlPoint.redPresence == 0) or !(!KothBlueControlPoint.locked and KothBlueControlPoint.capping == 0 and KothBlueControlPoint.bluePresence == 0 and KothBlueControlPoint.redPresence == 0))
-if (global.isHost and hostTimer &gt; 0 and 
-   ((!KothRedControlPoint.locked and KothRedControlPoint.capping == 0 and KothRedControlPoint.bluePresence == 0) or
-   (!KothBlueControlPoint.locked and KothBlueControlPoint.capping == 0 and KothBlueControlPoint.redPresence == 0))
-   and redTimer + blueTimer == 10800)
-{
-    hostTimer -= 1;
-    if (hostTimer == 0) global.winners = TEAM_SPECTATOR;
+        <argument kind="STRING">//automatically change maps if the server is empty or teams are at a standoff for too long
+if (global.isHost and hostTimer &gt; 0) {
+    if ((!KothRedControlPoint.locked and KothRedControlPoint.team == TEAM_RED and KothRedControlPoint.capping == 0 and KothRedControlPoint.bluePresence == 0) or
+        (!KothBlueControlPoint.locked and KothBlueControlPoint.team == TEAM_BLUE and KothBlueControlPoint.capping == 0 and KothBlueControlPoint.redPresence == 0))
+    {
+        hostTimer -= 1;
+        if (hostTimer == 0) {
+            if abs(redTimer - blueTimer) &lt; 30*30
+                global.winners = TEAM_SPECTATOR;
+            else if redTimer &lt; blueTimer
+                global.winners = TEAM_RED;
+            else if blueTimer &lt; redTimer
+                global.winners = TEAM_BLUE;
+        }
+    }
+    else
+        hostTimer = global.timeLimitMins*30*60;
 }
+    
+
 //both teams' countdown timers
 if (!KothRedControlPoint.locked or !KothBlueControlPoint.locked) {
     if KothBlueControlPoint.team == TEAM_RED &amp;&amp; redTimer &gt;0 redTimer-=1;


### PR DESCRIPTION
-Lack of action on CPs will force round end
--If timers are within 30 seconds of one another, stalemate
--Otherwise, lowest timer wins
