### PR TITLE
Uber length and charge rate changes.

### DIFF
--- a/Source/gg2/Objects/Weapons/Medigun.events/User Event 1.xml
+++ b/Source/gg2/Objects/Weapons/Medigun.events/User Event 1.xml
@@ -55,18 +55,17 @@
                     ownerPlayer.roundStats[HEALING] += healthGained;
                     
                     
-                    if(ubering == false &amp;&amp; uberCharge&lt;2000){
-                        uberCharge+=1;
+                    if(ubering == false &amp;&amp; uberCharge&lt;2400){
                         var setup;
                         setup = false;
                         if instance_exists(ControlPointSetupGate) {
                             if (ControlPointSetupGate.solid)
                                 setup = true;
                         }
-                        if(healTarget.object.hp &lt; healTarget.object.maxHp or setup) uberCharge += 0.5;
-                        if(healTarget.object.hp &lt; healTarget.object.maxHp/2 or setup) uberCharge += 1;
-                        if(uberCharge &gt;= 2000) {
-                            uberCharge = 2000;
+                        if(healTarget.object.hp = healTarget.object.maxHp or setup) uberCharge += 1.6;
+                        if(healTarget.object.hp &lt; healTarget.object.maxHp or setup) uberCharge += (24/35);
+                        if(uberCharge &gt;= 2400) {
+                            uberCharge = 2400;
                             if(global.isHost) {
                                 sendEventUberReady(ownerPlayer);
                                 doEventUberReady(ownerPlayer);


### PR DESCRIPTION
-Maximum uberCharge increased to 2400 in order to increase uber duration to 8 seconds.
-Changed the charge rate system from having three charge rates for players at 100%, 99%-51%, and <50% hp, to only having rates for full and under full hp since the heal rate is no longer hp dependent.
-Uber charges in 50 seconds on full hp players, in 35 seconds on damaged players.
