### PR TITLE
Server crash on disconnect without server

### DIFF
--- a/Source/gg2/Scripts/GameServer/sendLobbyUnreg.gml
+++ b/Source/gg2/Scripts/GameServer/sendLobbyUnreg.gml
@@ -1,4 +1,4 @@
-var lobbyBuffer, iplookup, lobbyIp;
+var lobbyBuffer, iplookup;
 lobbyBuffer = buffer_create();
 parseUuid("488984ac-45dc-86e1-9901-98dd1c01c064", lobbyBuffer); // Message Type "unregister"
 write_buffer(lobbyBuffer, GameServer.serverId);


### PR DESCRIPTION
the udp packet is no longer set if lobby ip lookup fails
