### PR TITLE
Dedicated mode now automatically mutes properly

### DIFF
--- a/Source/gg2/Scripts/AudioControl/AudioControlPlaySong.gml
+++ b/Source/gg2/Scripts/AudioControl/AudioControlPlaySong.gml
@@ -17,4 +17,6 @@ if(AudioControl.currentSong != -1) {
     } else {
         audio_play(AudioControl.currentSong, true);
     }
+    if (AudioControl.allAudioMuted = true)
+        audio_set_volume(AudioControl.currentSong, 0)
 }


### PR DESCRIPTION
Before it would require an additional toggle; this is a side effect of global_sound_volume no longer controlling the audiere extension
