### PR TITLE
Fix bug: Don't restart or reload plugins if disconnecting to download map

### DIFF
--- a/Source/gg2/Objects/Networking/Client.events/Destroy.xml
+++ b/Source/gg2/Objects/Networking/Client.events/Destroy.xml
@@ -26,7 +26,8 @@
         instance_destroy();
 
     room_goto_fix(returnRoom);
-    pluginscleanup();
+    if (global.serverPluginsInUse &amp;&amp; !noUnloadPlugins)
+        pluginscleanup();
 }
 
 </argument>

--- a/Source/gg2/Scripts/Client/ClientBeginStep.gml
+++ b/Source/gg2/Scripts/Client/ClientBeginStep.gml
@@ -52,7 +52,7 @@ do {
                 exit;
             }
 
-            if (string_length(plugins))
+            if (!noReloadPlugins && string_length(plugins))
             {
                 usePlugins = pluginsRequired || !global.serverPluginsPrompt;
                 if (global.serverPluginsPrompt)
@@ -82,6 +82,7 @@ do {
                     global.serverPluginsInUse = true;
                 }
             }
+            noReloadPlugins = false;
             
             if(advertisedMapMd5 != "")
             {
@@ -435,8 +436,12 @@ do {
                     var oldReturnRoom;
                     oldReturnRoom = returnRoom;
                     returnRoom = DownloadRoom;
+                    if (global.serverPluginsInUse)
+                        noUnloadPlugins = true;
                     event_perform(ev_destroy,0);
                     ClientCreate();
+                    if (global.serverPluginsInUse)
+                        noReloadPlugins = true;
                     returnRoom = oldReturnRoom;
                     usePreviousPwd = true;
                     exit;

--- a/Source/gg2/Scripts/Client/ClientCreate.gml
+++ b/Source/gg2/Scripts/Client/ClientCreate.gml
@@ -7,6 +7,8 @@
     }
     nocreate=false;
     usePreviousPwd = false;
+    noUnloadPlugins = false;
+    noReloadPlugins = false;
     
     global.players = ds_list_create();
     global.deserializeBuffer = buffer_create();

--- a/Source/gg2/Scripts/Plugins/pluginscleanup.gml
+++ b/Source/gg2/Scripts/Plugins/pluginscleanup.gml
@@ -1,10 +1,7 @@
 // cleans up server-sent plugins
-if (global.serverPluginsInUse)
+// Restart or quit GG2 so that plugins aren't kept in memory
+if (show_message_ext("Because you used this server's plugins, you will have to restart GG2 to play on another server.","Restart","","Quit") == 1)
 {
-    // Restart or quit GG2 so that plugins aren't kept in memory
-    if (show_message_ext("Because you used this server's plugins, you will have to restart GG2 to play on another server.","Restart","","Quit") == 1)
-    {
-        execute_program(parameter_string(0), "-restart", false);   
-    }
-    game_end();    
+    execute_program(parameter_string(0), "-restart", false);
 }
+game_end();


### PR DESCRIPTION
Currently, if you join a server with plugins and the map changes to one you don't have and need to download, you'll be asked to restart GG2. This fixes that.
