### PR TITLE
Prevent GM's sound stack from crashing Windows 8

### DIFF
--- a/Source/gg2/Scripts/Sound/playsound.gml
+++ b/Source/gg2/Scripts/Sound/playsound.gml
@@ -3,6 +3,10 @@
     vol = calculateVolume(argument0, argument1);
     if(vol==0) exit;
     
+    // Prevent crashes on Win8 (NT Kernel 6.2)
+    if (global.NTKernelVersion >= 6.2)
+        sound_stop(argument2);
+    
     sound_volume(argument2, vol);
     sound_pan(argument2, calculatePan(argument0));
     sound_play(argument2);

--- a/Source/gg2/Scripts/game_init.gml
+++ b/Source/gg2/Scripts/game_init.gml
@@ -393,6 +393,12 @@ global.launchMap = "";
     if(!directory_exists(working_directory + "\Plugins")) directory_create(working_directory + "\Plugins");
     loadplugins();
     
+    /* Windows 8 is known to crash GM when more than three (?) sounds play at once
+     * We'll store the kernel version (Win8 is 6.2, Win7 is 6.1) and check it there.
+     ***/
+    registry_set_root(1); // HKLM
+    global.NTKernelVersion = registry_read_real_ext("\SOFTWARE\Microsoft\Windows NT\CurrentVersion\", "CurrentVersion"); // SIC
+    
     if(global.dedicatedMode == 1) {
         AudioControlToggleMute();
         room_goto_fix(Menu);


### PR DESCRIPTION
If you don't like the registry way of doing things, there's a command line alternative. Very unfortunately I can't find an environment variable for this.
