### PR TITLE
Bubble filter/spamcontrol

### DIFF
--- a/Source/gg2/Constants.xml
+++ b/Source/gg2/Constants.xml
@@ -162,4 +162,5 @@
   <constant name="MUSIC_BOTH" value="1"/>
   <constant name="MUSIC_INGAME_ONLY" value="2"/>
   <constant name="MUSIC_NONE" value="3"/>
+  <constant name="BUBBLE_LIMIT" value="10"/>
 </constants>

--- a/Source/gg2/Objects/InGameElements/Character.events/End Step.xml
+++ b/Source/gg2/Objects/InGameElements/Character.events/End Step.xml
@@ -136,6 +136,9 @@ if (player == global.myself)
         view_yview[0] = y-view_hview[0]/2;
     }
 }
+//make the bubble buffer decrease
+//I'll probably tweak this value a little more in the future
+player.bubbleBuffer -= 0.01
 </argument>
       </arguments>
     </action>

--- a/Source/gg2/Objects/InGameElements/Player.events/Create.xml
+++ b/Source/gg2/Objects/InGameElements/Player.events/Create.xml
@@ -20,6 +20,7 @@
     socket = -1;
     name = "";
     kicked = false;
+    bubbleBuffer = 0;
     
     // client setting stuff; set to defaults
     queueJump = false;

--- a/Source/gg2/Scripts/GameServer/processClientCommands.gml
+++ b/Source/gg2/Scripts/GameServer/processClientCommands.gml
@@ -182,8 +182,10 @@ while(commandLimitRemaining > 0) {
             write_ubyte(global.sendBuffer, CHAT_BUBBLE);
             write_ubyte(global.sendBuffer, playerId);
             write_ubyte(global.sendBuffer, bubbleImage);
-            
-            setChatBubble(player, bubbleImage);
+            if player.bubbleBuffer < BUBBLE_LIMIT{
+               setChatBubble(player, bubbleImage);
+               player.bubbleBuffer += 1
+            }
             break;
             
         case BUILD_SENTRY:


### PR DESCRIPTION
Not going to completely mute bubbles since the bubblespam fanboys will
freak out. Instead, after a set bubble limit, the bubblespam will slow
down, also apparently the medic button is special so the muted player
will still be able to call for a medic.
