### PR TITLE
Run plugins in their own little environments

### DIFF
--- a/Source/gg2/Objects/PluginEnvironment.xml
+++ b/Source/gg2/Objects/PluginEnvironment.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<object id="832">
+  <sprite/>
+  <solid>false</solid>
+  <visible>false</visible>
+  <depth>0</depth>
+  <persistent>true</persistent>
+  <parent/>
+  <mask/>
+</object>

--- a/Source/gg2/Objects/_resources.list.xml
+++ b/Source/gg2/Objects/_resources.list.xml
@@ -14,4 +14,5 @@
   <resource name="RoomChangeObserver" type="RESOURCE"/>
   <resource name="Updater" type="RESOURCE"/>
   <resource name="RateController" type="RESOURCE"/>
+  <resource name="PluginEnvironment" type="RESOURCE"/>
 </resources>

--- a/Source/gg2/Scripts/Plugins/loadplugins.gml
+++ b/Source/gg2/Scripts/Plugins/loadplugins.gml
@@ -1,6 +1,6 @@
 // self-explanatory
 // borrowed file-search code from Port
-var file, pattern, prefix, list, fp, i;
+var file, pattern, prefix, list, fp, i, env;
 
 // Prefix since results from file_find_* don't include path
 prefix = working_directory + "\Plugins\";
@@ -22,8 +22,16 @@ for (i = 0; i < ds_list_size(list); i += 1)
     fp = file_text_open_write(working_directory + "\last_plugin.log");
     file_text_write_string(fp, prefix + file);
     file_text_close(fp);
-    // Execute    
-    execute_file(prefix + file);
+    // Create persistent environment for plugin (so its variables won't collide)
+    env = instance_create(0, 0, PluginEnvironment);
+    // Allows plugins to detect which mode they're running in
+    env.isServerSentPlugin = false;
+    env.isLocalPlugin = true;
+    // So the plugin can locate its resources
+    env.directory = prefix;
+    // Execute
+    with (env)
+        execute_file(prefix + file);
 }
 
 // Clear up


### PR DESCRIPTION
As a convenient bonus for plugins, this means they have their own little persistent object to play with, and they get nice variable names for the information passed in, instead of (argument0). Oh, and there's a better way to detect whether it's a server-sent plugin now.
