### PR TITLE
Update Faucet HTTP to v1.1

### DIFF
--- a/Source/gg2/Scripts/Faucet HTTP/__http_client_destroy.gml
+++ b/Source/gg2/Scripts/Faucet HTTP/__http_client_destroy.gml
@@ -1,8 +1,8 @@
 // ***
-// This function forms part of Faucet HTTP v1.0
+// This function forms part of Faucet HTTP v1.1
 // https://github.com/TazeTSchnitzel/Faucet-HTTP-Extension
 // 
-// Copyright (c) 2013-2014, Andrea Faulds <ajf@ajf.me>
+// Copyright (c) 2013-2015, Andrea Faulds <ajf@ajf.me>
 // 
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above

--- a/Source/gg2/Scripts/Faucet HTTP/__http_client_step.gml
+++ b/Source/gg2/Scripts/Faucet HTTP/__http_client_step.gml
@@ -1,8 +1,8 @@
 // ***
-// This function forms part of Faucet HTTP v1.0
+// This function forms part of Faucet HTTP v1.1
 // https://github.com/TazeTSchnitzel/Faucet-HTTP-Extension
 // 
-// Copyright (c) 2013-2014, Andrea Faulds <ajf@ajf.me>
+// Copyright (c) 2013-2015, Andrea Faulds <ajf@ajf.me>
 // 
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above

--- a/Source/gg2/Scripts/Faucet HTTP/__http_construct_url.gml
+++ b/Source/gg2/Scripts/Faucet HTTP/__http_construct_url.gml
@@ -1,8 +1,8 @@
 // ***
-// This function forms part of Faucet HTTP v1.0
+// This function forms part of Faucet HTTP v1.1
 // https://github.com/TazeTSchnitzel/Faucet-HTTP-Extension
 // 
-// Copyright (c) 2013-2014, Andrea Faulds <ajf@ajf.me>
+// Copyright (c) 2013-2015, Andrea Faulds <ajf@ajf.me>
 // 
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above

--- a/Source/gg2/Scripts/Faucet HTTP/__http_init.gml
+++ b/Source/gg2/Scripts/Faucet HTTP/__http_init.gml
@@ -1,8 +1,8 @@
 // ***
-// This function forms part of Faucet HTTP v1.0
+// This function forms part of Faucet HTTP v1.1
 // https://github.com/TazeTSchnitzel/Faucet-HTTP-Extension
 // 
-// Copyright (c) 2013-2014, Andrea Faulds <ajf@ajf.me>
+// Copyright (c) 2013-2015, Andrea Faulds <ajf@ajf.me>
 // 
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above

--- a/Source/gg2/Scripts/Faucet HTTP/__http_parse_header.gml
+++ b/Source/gg2/Scripts/Faucet HTTP/__http_parse_header.gml
@@ -1,8 +1,8 @@
 // ***
-// This function forms part of Faucet HTTP v1.0
+// This function forms part of Faucet HTTP v1.1
 // https://github.com/TazeTSchnitzel/Faucet-HTTP-Extension
 // 
-// Copyright (c) 2013-2014, Andrea Faulds <ajf@ajf.me>
+// Copyright (c) 2013-2015, Andrea Faulds <ajf@ajf.me>
 // 
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above

--- a/Source/gg2/Scripts/Faucet HTTP/__http_parse_hex.gml
+++ b/Source/gg2/Scripts/Faucet HTTP/__http_parse_hex.gml
@@ -1,8 +1,8 @@
 // ***
-// This function forms part of Faucet HTTP v1.0
+// This function forms part of Faucet HTTP v1.1
 // https://github.com/TazeTSchnitzel/Faucet-HTTP-Extension
 // 
-// Copyright (c) 2013-2014, Andrea Faulds <ajf@ajf.me>
+// Copyright (c) 2013-2015, Andrea Faulds <ajf@ajf.me>
 // 
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above

--- a/Source/gg2/Scripts/Faucet HTTP/__http_parse_url.gml
+++ b/Source/gg2/Scripts/Faucet HTTP/__http_parse_url.gml
@@ -1,8 +1,8 @@
 // ***
-// This function forms part of Faucet HTTP v1.0
+// This function forms part of Faucet HTTP v1.1
 // https://github.com/TazeTSchnitzel/Faucet-HTTP-Extension
 // 
-// Copyright (c) 2013-2014, Andrea Faulds <ajf@ajf.me>
+// Copyright (c) 2013-2015, Andrea Faulds <ajf@ajf.me>
 // 
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above

--- a/Source/gg2/Scripts/Faucet HTTP/__http_prepare_request.gml
+++ b/Source/gg2/Scripts/Faucet HTTP/__http_prepare_request.gml
@@ -1,8 +1,8 @@
 // ***
-// This function forms part of Faucet HTTP v1.0
+// This function forms part of Faucet HTTP v1.1
 // https://github.com/TazeTSchnitzel/Faucet-HTTP-Extension
 // 
-// Copyright (c) 2013-2014, Andrea Faulds <ajf@ajf.me>
+// Copyright (c) 2013-2015, Andrea Faulds <ajf@ajf.me>
 // 
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above
@@ -21,13 +21,19 @@
 // void __http_prepare_request(real client, string url, real headers)
 
 // client - HttpClient object to prepare
+// method - method of request ('GET' or 'POST')
 // url - URL to send GET request to
 // headers - ds_map of extra headers to send, -1 if none
+// requestBody - buffer of request body to send, 0 if none
+// requestMimeType - content type of request body, '' if no request body
 
-var client, url, headers;
+var client, method, url, headers, _requestBody, _requestBodyMimeType;
 client = argument0;
-url = argument1;
-headers = argument2;
+method = argument1;
+url = argument2;
+headers = argument3;
+_requestBody = argument4;
+_requestBodyMimeType = argument5;
 
 var parsed;
 parsed = __http_parse_url(url);
@@ -59,7 +65,10 @@ with (client)
     responseBodyProgress = -1;
     responseHeaders = ds_map_create();
     requestUrl = url;
+    requestMethod = method;
     requestHeaders = headers;
+    requestBody = _requestBody;
+    requestBodyMimeType = _requestBodyMimeType;
 
     //  Request       = Request-Line              ; Section 5.1
     //                  *(( general-header        ; Section 4.5
@@ -73,9 +82,9 @@ with (client)
     // elements are separated by SP characters. No CR or LF is allowed
     // except in the final CRLF sequence."
     if (ds_map_exists(parsed, 'query'))
-        write_string(socket, 'GET ' + ds_map_find_value(parsed, 'abs_path') + '?' + ds_map_find_value(parsed, 'query') + ' HTTP/1.1' + CRLF);
+        write_string(socket, requestMethod + ' ' + ds_map_find_value(parsed, 'abs_path') + '?' + ds_map_find_value(parsed, 'query') + ' HTTP/1.1' + CRLF);
     else
-        write_string(socket, 'GET ' + ds_map_find_value(parsed, 'abs_path') + ' HTTP/1.1' + CRLF);
+        write_string(socket, requestMethod + ' ' + ds_map_find_value(parsed, 'abs_path') + ' HTTP/1.1' + CRLF);
 
     // "A client MUST include a Host header field in all HTTP/1.1 request
     // messages."
@@ -95,7 +104,15 @@ with (client)
     // "If no Accept-Encoding field is present in a request, the server MAY
     // assume that the client will accept any content coding."
     write_string(socket, 'Accept-Encoding:' + CRLF);
+
+    // Request body meta data
+    if (requestBody)
+    {
+        write_string(socket, 'Content-Length: ' + string(buffer_size(requestBody)) + CRLF);
+        write_string(socket, 'Content-Type: ' + requestBodyMimeType + CRLF);
     
+    }
+        
     // If headers specified
     if (headers != -1)
     {
@@ -109,6 +126,10 @@ with (client)
     
     // Send extra CRLF to terminate request
     write_string(socket, CRLF);
+    
+    // Request body itself
+    if (requestBody)
+        write_buffer(socket, requestBody);
     
     socket_send(socket);
 

--- a/Source/gg2/Scripts/Faucet HTTP/__http_resolve_path.gml
+++ b/Source/gg2/Scripts/Faucet HTTP/__http_resolve_path.gml
@@ -1,8 +1,8 @@
 // ***
-// This function forms part of Faucet HTTP v1.0
+// This function forms part of Faucet HTTP v1.1
 // https://github.com/TazeTSchnitzel/Faucet-HTTP-Extension
 // 
-// Copyright (c) 2013-2014, Andrea Faulds <ajf@ajf.me>
+// Copyright (c) 2013-2015, Andrea Faulds <ajf@ajf.me>
 // 
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above

--- a/Source/gg2/Scripts/Faucet HTTP/__http_resolve_url.gml
+++ b/Source/gg2/Scripts/Faucet HTTP/__http_resolve_url.gml
@@ -1,8 +1,8 @@
 // ***
-// This function forms part of Faucet HTTP v1.0
+// This function forms part of Faucet HTTP v1.1
 // https://github.com/TazeTSchnitzel/Faucet-HTTP-Extension
 // 
-// Copyright (c) 2013-2014, Andrea Faulds <ajf@ajf.me>
+// Copyright (c) 2013-2015, Andrea Faulds <ajf@ajf.me>
 // 
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above
@@ -89,7 +89,7 @@ else if (((string_char_at(refUrl, 1) == '/' and string_length(refUrl) > 1) or re
     {
         var path, query;
         path = string_copy(refUrl, 1, queryPos - 1);
-        query = string_copy(refUrl, queryPos + 1, string_length(relUrl) - queryPos);
+        query = string_copy(refUrl, queryPos + 1, string_length(refUrl) - queryPos);
         path = __http_resolve_path(ds_map_find_value(urlParts, 'abs_path'), path);
         ds_map_replace(urlParts, 'abs_path', path);
         if (ds_map_exists(urlParts, 'query'))

--- a/Source/gg2/Scripts/Faucet HTTP/__http_split.gml
+++ b/Source/gg2/Scripts/Faucet HTTP/__http_split.gml
@@ -1,8 +1,8 @@
 // ***
-// This function forms part of Faucet HTTP v1.0
+// This function forms part of Faucet HTTP v1.1
 // https://github.com/TazeTSchnitzel/Faucet-HTTP-Extension
 // 
-// Copyright (c) 2013-2014, Andrea Faulds <ajf@ajf.me>
+// Copyright (c) 2013-2015, Andrea Faulds <ajf@ajf.me>
 // 
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above

--- a/Source/gg2/Scripts/Faucet HTTP/_resources.list.xml
+++ b/Source/gg2/Scripts/Faucet HTTP/_resources.list.xml
@@ -13,6 +13,8 @@
   <resource name="__http_client_destroy" type="RESOURCE"/>
   <resource name="http_new_get" type="RESOURCE"/>
   <resource name="http_new_get_ex" type="RESOURCE"/>
+  <resource name="http_new_post" type="RESOURCE"/>
+  <resource name="http_new_post_ex" type="RESOURCE"/>
   <resource name="http_step" type="RESOURCE"/>
   <resource name="http_status_code" type="RESOURCE"/>
   <resource name="http_reason_phrase" type="RESOURCE"/>

--- a/Source/gg2/Scripts/Faucet HTTP/http_destroy.gml
+++ b/Source/gg2/Scripts/Faucet HTTP/http_destroy.gml
@@ -1,8 +1,8 @@
 // ***
-// This function forms part of Faucet HTTP v1.0
+// This function forms part of Faucet HTTP v1.1
 // https://github.com/TazeTSchnitzel/Faucet-HTTP-Extension
 // 
-// Copyright (c) 2013-2014, Andrea Faulds <ajf@ajf.me>
+// Copyright (c) 2013-2015, Andrea Faulds <ajf@ajf.me>
 // 
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above

--- a/Source/gg2/Scripts/Faucet HTTP/http_new_get.gml
+++ b/Source/gg2/Scripts/Faucet HTTP/http_new_get.gml
@@ -1,8 +1,8 @@
 // ***
-// This function forms part of Faucet HTTP v1.0
+// This function forms part of Faucet HTTP v1.1
 // https://github.com/TazeTSchnitzel/Faucet-HTTP-Extension
 // 
-// Copyright (c) 2013-2014, Andrea Faulds <ajf@ajf.me>
+// Copyright (c) 2013-2015, Andrea Faulds <ajf@ajf.me>
 // 
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above
@@ -34,5 +34,5 @@ if (!variable_global_exists('__HttpClient'))
     __http_init();
 
 client = instance_create(0, 0, global.__HttpClient);
-__http_prepare_request(client, url, -1);
+__http_prepare_request(client, 'GET', url, -1, 0, '');
 return client;

--- a/Source/gg2/Scripts/Faucet HTTP/http_new_get_ex.gml
+++ b/Source/gg2/Scripts/Faucet HTTP/http_new_get_ex.gml
@@ -1,8 +1,8 @@
 // ***
-// This function forms part of Faucet HTTP v1.0
+// This function forms part of Faucet HTTP v1.1
 // https://github.com/TazeTSchnitzel/Faucet-HTTP-Extension
 // 
-// Copyright (c) 2013-2014, Andrea Faulds <ajf@ajf.me>
+// Copyright (c) 2013-2015, Andrea Faulds <ajf@ajf.me>
 // 
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above
@@ -36,5 +36,5 @@ if (!variable_global_exists('__HttpClient'))
     __http_init();
 
 client = instance_create(0, 0, global.__HttpClient);
-__http_prepare_request(client, url, headers);
+__http_prepare_request(client, 'GET', url, headers, 0, '');
 return client;

--- a/Source/gg2/Scripts/Faucet HTTP/http_new_post.gml
+++ b/Source/gg2/Scripts/Faucet HTTP/http_new_post.gml
@@ -17,14 +17,26 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 // ***
 
-// Gets the response body returned by an HTTP request as a buffer
-// real http_response_body(real client)
+// Makes a POST HTTP request
+// real http_new_post(string url, real body, string mimeType)
 
-// client - HttpClient object
+// url - URL to send POST request to
+// body - buffer containing the request body
+// mimeType - string containing the mime-type of the request body
 
-// Return value is a buffer if client hasn't errored and is finished
+// Return value is an HttpClient instance that can be passed to
+// fct_http_request_status etc.
+// (errors on failure to parse URL)
 
-var client;
-client = argument0;
+var url, body, mimeType, client;
 
-return client.responseBody;
+url = argument0;
+body = argument1;
+mimeType = argument2;
+
+if (!variable_global_exists('__HttpClient'))
+    __http_init();
+
+client = instance_create(0, 0, global.__HttpClient);
+__http_prepare_request(client, 'POST', url, -1, body, mimeType);
+return client;

--- a/Source/gg2/Scripts/Faucet HTTP/http_new_post_ex.gml
+++ b/Source/gg2/Scripts/Faucet HTTP/http_new_post_ex.gml
@@ -17,14 +17,28 @@
 // OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 // ***
 
-// Gets the response body returned by an HTTP request as a buffer
-// real http_response_body(real client)
+// Makes a POST HTTP request with custom headers
+// real http_new_post_ex(string url, real body, string mimeType, real headers)
 
-// client - HttpClient object
+// url - URL to send POST request to
+// body - buffer containing the request body
+// mimeType - string containing the mime-type of the request body
+// headers - ds_map of extra headers to send
 
-// Return value is a buffer if client hasn't errored and is finished
+// Return value is an HttpClient instance that can be passed to
+// fct_http_request_status etc.
+// (errors on failure to parse URL)
 
-var client;
-client = argument0;
+var url, body, mimeType, heeaders, client;
 
-return client.responseBody;
+url = argument0;
+body = argument1;
+mimeType = argument2;
+headers = argument3;
+
+if (!variable_global_exists('__HttpClient'))
+    __http_init();
+
+client = instance_create(0, 0, global.__HttpClient);
+__http_prepare_request(client, 'POST', url, headers, body, mimeType);
+return client;

--- a/Source/gg2/Scripts/Faucet HTTP/http_reason_phrase.gml
+++ b/Source/gg2/Scripts/Faucet HTTP/http_reason_phrase.gml
@@ -1,8 +1,8 @@
 // ***
-// This function forms part of Faucet HTTP v1.0
+// This function forms part of Faucet HTTP v1.1
 // https://github.com/TazeTSchnitzel/Faucet-HTTP-Extension
 // 
-// Copyright (c) 2013-2014, Andrea Faulds <ajf@ajf.me>
+// Copyright (c) 2013-2015, Andrea Faulds <ajf@ajf.me>
 // 
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above

--- a/Source/gg2/Scripts/Faucet HTTP/http_response_body_progress.gml
+++ b/Source/gg2/Scripts/Faucet HTTP/http_response_body_progress.gml
@@ -1,8 +1,8 @@
 // ***
-// This function forms part of Faucet HTTP v1.0
+// This function forms part of Faucet HTTP v1.1
 // https://github.com/TazeTSchnitzel/Faucet-HTTP-Extension
 // 
-// Copyright (c) 2013-2014, Andrea Faulds <ajf@ajf.me>
+// Copyright (c) 2013-2015, Andrea Faulds <ajf@ajf.me>
 // 
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above

--- a/Source/gg2/Scripts/Faucet HTTP/http_response_body_size.gml
+++ b/Source/gg2/Scripts/Faucet HTTP/http_response_body_size.gml
@@ -1,8 +1,8 @@
 // ***
-// This function forms part of Faucet HTTP v1.0
+// This function forms part of Faucet HTTP v1.1
 // https://github.com/TazeTSchnitzel/Faucet-HTTP-Extension
 // 
-// Copyright (c) 2013-2014, Andrea Faulds <ajf@ajf.me>
+// Copyright (c) 2013-2015, Andrea Faulds <ajf@ajf.me>
 // 
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above

--- a/Source/gg2/Scripts/Faucet HTTP/http_response_headers.gml
+++ b/Source/gg2/Scripts/Faucet HTTP/http_response_headers.gml
@@ -1,8 +1,8 @@
 // ***
-// This function forms part of Faucet HTTP v1.0
+// This function forms part of Faucet HTTP v1.1
 // https://github.com/TazeTSchnitzel/Faucet-HTTP-Extension
 // 
-// Copyright (c) 2013-2014, Andrea Faulds <ajf@ajf.me>
+// Copyright (c) 2013-2015, Andrea Faulds <ajf@ajf.me>
 // 
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above

--- a/Source/gg2/Scripts/Faucet HTTP/http_status_code.gml
+++ b/Source/gg2/Scripts/Faucet HTTP/http_status_code.gml
@@ -1,8 +1,8 @@
 // ***
-// This function forms part of Faucet HTTP v1.0
+// This function forms part of Faucet HTTP v1.1
 // https://github.com/TazeTSchnitzel/Faucet-HTTP-Extension
 // 
-// Copyright (c) 2013-2014, Andrea Faulds <ajf@ajf.me>
+// Copyright (c) 2013-2015, Andrea Faulds <ajf@ajf.me>
 // 
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above

--- a/Source/gg2/Scripts/Faucet HTTP/http_step.gml
+++ b/Source/gg2/Scripts/Faucet HTTP/http_step.gml
@@ -1,8 +1,8 @@
 // ***
-// This function forms part of Faucet HTTP v1.0
+// This function forms part of Faucet HTTP v1.1
 // https://github.com/TazeTSchnitzel/Faucet-HTTP-Extension
 // 
-// Copyright (c) 2013-2014, Andrea Faulds <ajf@ajf.me>
+// Copyright (c) 2013-2015, Andrea Faulds <ajf@ajf.me>
 // 
 // Permission to use, copy, modify, and/or distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above
@@ -29,7 +29,7 @@
 
 // Example usage:
 // req = http_new_get("http://example.com/x.txt");
-// while (http_step(req)) {}
+// while (!http_step(req)) {}
 // if (http_status_code(req) != 200) {
 //     // Errored!
 // } else {

--- a/Source/gg2/Scripts/_resources.list.xml
+++ b/Source/gg2/Scripts/_resources.list.xml
@@ -55,8 +55,8 @@
   <resource name="promptRestartOrQuit" type="RESOURCE"/>
   <resource name="split" type="RESOURCE"/>
   <resource name="draw_pinched_blackrect" type="RESOURCE"/>
-  <resource name="Faucet HTTP" type="GROUP"/>
   <resource name="move_all_bullets" type="RESOURCE"/>
   <resource name="move_all_gore" type="RESOURCE"/>
   <resource name="classname" type="RESOURCE"/>
+  <resource name="Faucet HTTP" type="GROUP"/>
 </resources>


### PR DESCRIPTION
See release notes: https://github.com/TazeTSchnitzel/Faucet-HTTP-Extension/releases/tag/V1.1

The main reason to update is because there's a bug in `__http_resolve_url` which makes redirects cause errors in some cases. POST support is kinda cool too, but we don't actually need that.

This may not need meticulous code review, as the library is maintained by me, not GG2.