### PR TITLE
Escape newlines rather than prohibiting in names

### DIFF
--- a/Source/gg2/Objects/Alternative Objects/2013 Halloween Mini-Haxxy Rewards/Ghost.events/Draw.xml
+++ b/Source/gg2/Objects/Alternative Objects/2013 Halloween Mini-Haxxy Rewards/Ghost.events/Draw.xml
@@ -24,7 +24,7 @@ if (distance_to_point(mouse_x, mouse_y) &lt; 25)
         draw_set_color(c_black);
     else
         draw_set_color(c_white);
-    draw_text(round(x), round(y) - 35, 'Ghost of ' + owner.name);
+    draw_text(round(x), round(y) - 35, 'Ghost of ' + sanitiseNewlines(owner.name));
 }  
 
 

--- a/Source/gg2/Objects/InGameElements/Sentry.events/Draw.xml
+++ b/Source/gg2/Objects/InGameElements/Sentry.events/Draw.xml
@@ -42,7 +42,7 @@ if(distance_to_point(mouse_x, mouse_y)&lt;25 &amp;&amp; global.myself.team == te
     } else {
         draw_set_color(c_blue);
     }
-    draw_text(xr, yr-45, ownerPlayer.name + "'s");
+    draw_text(xr, yr-45, sanitiseNewlines(ownerPlayer.name) + "'s");
     draw_text(xr, yr-35, "Autogun");
 }
 </argument>

--- a/Source/gg2/Objects/Menus/Hosting Menu Elements/HostOptionsController.events/Create.xml
+++ b/Source/gg2/Objects/Menus/Hosting Menu Elements/HostOptionsController.events/Create.xml
@@ -35,10 +35,6 @@ bgtabs = true;
 menu_addedit_text2("Server Name:", "global.serverName", '
     var newName;
     newName = string_copy(argument0, 0, 25);
-    if string_count("#",newName) &gt; 0 {
-        show_message("Invalid character ' + "'\#'" + ' in server name");
-        newName = "I &lt;3 Bacon";
-    }
     gg2_write_ini("Server", "ServerName", newName);
     return newName;
 ');

--- a/Source/gg2/Objects/Menus/Lobby Elements/LobbyController.events/Draw.xml
+++ b/Source/gg2/Objects/Menus/Lobby Elements/LobbyController.events/Draw.xml
@@ -54,13 +54,13 @@ for(i=offset; i&lt;ds_list_size(servers) and i&lt;offset+items; i+=1)
     draw_set_halign(fa_left);
     if(server.private)
         draw_sprite(ControlPointLockS,0,xbegin,ybegin+pixeloffset+5);
-    draw_text(xbegin+10, ybegin+pixeloffset,"["+server.playerstring+"]");
-    draw_text(xbegin+95, ybegin+pixeloffset,server.name);
+    draw_text(xbegin+10, ybegin+pixeloffset,"["+sanitiseNewlines(server.playerstring)+"]");
+    draw_text(xbegin+95, ybegin+pixeloffset,sanitiseNewlines(server.name));
     if(ds_map_exists(server.infos, "map"))
-        draw_text(xbegin+95,  ybegin+pixeloffset,"#"+ds_map_find_value(server.infos, "map"));
+        draw_text(xbegin+95,  ybegin+pixeloffset,'#'+sanitiseNewlines(ds_map_find_value(server.infos, "map")));
     
     draw_set_halign(fa_right);
-    draw_text(xbegin+425, ybegin+pixeloffset,server.shortgame);
+    draw_text(xbegin+425, ybegin+pixeloffset,sanitiseNewlines(server.shortgame));
     
     /* Draw latency and color indicators */
     if(server.pingFinished) {

--- a/Source/gg2/Objects/Menus/Lobby Elements/LobbyController.events/Step.xml
+++ b/Source/gg2/Objects/Menus/Lobby Elements/LobbyController.events/Step.xml
@@ -92,7 +92,6 @@
                             server.shortgame += " " + ds_map_find_value(server.infos, "game_ver");
                     }
                     server.name = ds_map_find_value(server.infos, "name");
-                    server.name = string_replace(server.name, "#", "\#");
                     serversRead += 1;
                     serverInfoLength = -1;
                 }
@@ -135,20 +134,19 @@
             {
                 var question;
                 question = "The selected game is not compatible with this client.##";
-                question += "Server: " + string_replace(ds_map_find_value(server.infos, "name"), "#", "\#")+"#";
+                question += "Server: " + sanitiseNewlines(ds_map_find_value(server.infos, "name")) + "#";
                 if(ds_map_exists(server.infos, "game"))
-                    question += "Game/Mod: " + string_replace(ds_map_find_value(server.infos, "game"), "#", "\#")+"#";
+                    question += "Game/Mod: " + sanitiseNewlines(ds_map_find_value(server.infos, "game")) + "#";
                 if(ds_map_exists(server.infos, "game_ver"))
-                    question += "Version: " + string_replace(ds_map_find_value(server.infos, "game_ver"), "#", "\#")+"#";
+                    question += "Version: " + sanitiseNewlines(ds_map_find_value(server.infos, "game_ver")) + "#";
                 if(ds_map_exists(server.infos, "game_url"))
                 {
                     var gameurl, reallyvisit;
-                    gameurl = string_replace(ds_map_find_value(server.infos, "game_url"), "#", "\#");
+                    gameurl = sanitiseNewlines(ds_map_find_value(server.infos, "game_url"));
                     question += "Website: " + gameurl + "##Do you want to visit this website now?";
                     if(show_question(question))
                         if(show_question("Warning: The website link is provided by the game server you selected and could lead anywhere.#Really visit '"+gameurl+"'?"))
                             action_splash_web(ds_map_find_value(server.infos, "game_url"), 1);
-
                 }
                 else
                 {

--- a/Source/gg2/Objects/Menus/Lobby Elements/LobbyNameController.events/Create.xml
+++ b/Source/gg2/Objects/Menus/Lobby Elements/LobbyNameController.events/Create.xml
@@ -20,10 +20,6 @@ menu_background(272, 24, 8, 12, 4);
 menu_addedit_text2("Player name:", "global.playerName", '
     var newName;
     newName = string_copy(argument0, 0, min(string_length(argument0), MAX_PLAYERNAME_LENGTH));
-    if string_count("#",newName) &gt; 0 {
-        show_message("Invalid character ' + "'\#'" + ' in name");
-        newName = "Player";
-    }
     gg2_write_ini("Settings", "PlayerName", newName);
     oldPlayerName = newName;
     return newName;

--- a/Source/gg2/Objects/Menus/MenuController.events/Draw.xml
+++ b/Source/gg2/Objects/Menus/MenuController.events/Draw.xml
@@ -182,7 +182,7 @@ if(view_hview[0] &lt; 600)
             }
             break;
         }
-        draw_text(view_xview[0]+xbegin+valueoffset,view_yview[0]+ybegin+i*spacing,val);
+        draw_text(view_xview[0]+xbegin+valueoffset,view_yview[0]+ybegin+i*spacing,sanitiseNewlines(val));
     }
 }
 </argument>

--- a/Source/gg2/Objects/Menus/Options Menus/OptionsController.events/Create.xml
+++ b/Source/gg2/Objects/Menus/Options Menus/OptionsController.events/Create.xml
@@ -27,10 +27,6 @@
     menu_addedit_text2("Player name:", "global.playerName", '
         var newName;
         newName = string_copy(argument0, 0, min(string_length(argument0), MAX_PLAYERNAME_LENGTH));
-        if string_count("#",newName) &gt; 0 {
-            show_message("Invalid character ' + "'\#'" + ' in name");
-            newName = "Player";
-        }
         gg2_write_ini("Settings", "PlayerName", newName);
         if(room != Options and newName != oldPlayerName)
         {

--- a/Source/gg2/Objects/Overlays/DeathCam.events/Draw.xml
+++ b/Source/gg2/Objects/Overlays/DeathCam.events/Draw.xml
@@ -33,7 +33,7 @@ else draw_set_color(c_red);
 
 
 draw_text_transformed(view_xview+xsize/2,view_yview+30, killmessage,2,2,0);
-draw_text_transformed(view_xview+xsize/2,view_yview+60, name,2,2,0);
+draw_text_transformed(view_xview+xsize/2,view_yview+60, sanitiseNewlines(name),2,2,0);
 if maxHp != 0 {
     if killedby.object!=-1  {
         draw_healthbar(xoffset+xsize/2-18, yoffset+ysize-50-18, xoffset+xsize/2+18, yoffset+ysize-50+18, hp*100/maxHp,c_black,c_red,c_green,3,true,false);

--- a/Source/gg2/Objects/Overlays/HealedHud.events/Draw.xml
+++ b/Source/gg2/Objects/Overlays/HealedHud.events/Draw.xml
@@ -18,7 +18,7 @@
     yoffset = view_yview[0];
     mid = view_wview[0]/2;
 
-    HUDwidth = string_width("Healer: "+healer)+20;
+    HUDwidth = string_width("Healer: " + sanitiseNewlines(healer))+20;
     
     draw_set_halign(fa_center);
     draw_set_color(c_white);
@@ -31,7 +31,7 @@
         
     draw_sprite_stretched_ext(sprite_index, global.myself.team == TEAM_BLUE, 
         xoffset+mid-(HUDwidth/2)+20, drawy, HUDwidth, 36, c_white, 1);
-    draw_text_color(xoffset+mid+20, drawy+12, "Healer: " +healer, c_white, c_white, c_white, c_white, 1);    
+    draw_text_color(xoffset+mid+20, drawy+12, "Healer: " + sanitiseNewlines(healer), c_white, c_white, c_white, c_white, 1);    
     draw_healthbar(xoffset+mid-(HUDwidth/2)-24, drawy+2,xoffset+mid-(HUDwidth/2)+20, drawy+34,healerhp*100/120,c_black,c_white,c_white,3,true,false);
     draw_healthbar(xoffset+mid-(HUDwidth/2)+30, drawy+20, xoffset+mid+HUDwidth/2+10, drawy+28, healerUberCharge*100/2000,c_black,c_white,c_white,0,true,true);
     draw_sprite_stretched_ext(HealedHudHPS, global.myself.team == TEAM_BLUE,

--- a/Source/gg2/Objects/Overlays/HealingHud.events/Draw.xml
+++ b/Source/gg2/Objects/Overlays/HealingHud.events/Draw.xml
@@ -20,7 +20,7 @@
     xoffset = view_xview[0];
     yoffset = view_yview[0]-600+ysize;
     mid = view_wview[0]/2;
-    HUDwidth = string_width("Healing: "+target.name)+20;
+    HUDwidth = string_width("Healing: " + sanitiseNewlines(target.name))+20;
     
     draw_set_halign(fa_center);
     draw_set_color(c_white);
@@ -28,7 +28,7 @@
     if (target.object != -1) {
         draw_sprite_stretched_ext(sprite_index, global.myself.team == TEAM_BLUE, 
         xoffset+mid-(HUDwidth/2)+20, yoffset+450, HUDwidth, 36, c_white, 1);
-        draw_text_color(xoffset+mid+20, yoffset+462, "Healing: " +target.name, c_white, c_white, c_white, c_white, 1);    
+        draw_text_color(xoffset+mid+20, yoffset+462, "Healing: " + sanitiseNewlines(target.name), c_white, c_white, c_white, c_white, 1);    
         draw_healthbar(xoffset+mid-(HUDwidth/2)-24, yoffset+452,xoffset+mid-(HUDwidth/2)+20, yoffset+484,floor(target.object.hp*100/target.object.maxHp),c_black,c_white,c_white,3,true,false);
         draw_sprite_stretched_ext(HealedHudHPS, global.myself.team == TEAM_BLUE,
         xoffset+mid-(HUDwidth/2)-26, yoffset+450,48,36,c_white, 1);

--- a/Source/gg2/Objects/Overlays/KillLog.events/Draw.xml
+++ b/Source/gg2/Objects/Overlays/KillLog.events/Draw.xml
@@ -25,10 +25,10 @@ draw_set_valign(fa_center);
 
 for (i = 0; i &lt; ds_list_size(kills); i += 1) {
     map = ds_list_find_value(kills, i);
-    n1 = ds_map_find_value(map, "name1"); // Name of the Player who killed
+    n1 = sanitiseNewlines(ds_map_find_value(map, "name1")); // Name of the Player who killed
     t1 = ds_map_find_value(map, "team1"); // Their team
     w1 = ds_map_find_value(map, "weapon"); // Their weapon sprite
-    n2 = ds_map_find_value(map, "name2"); // Name of the Player who died
+    n2 = sanitiseNewlines(ds_map_find_value(map, "name2")); // Name of the Player who died
     t2 = ds_map_find_value(map, "team2"); // Their team
     in = ds_map_find_value(map, "inthis"); // Am I involved in this event?
     str = ds_map_find_value(map, "string"); // Special text: Finish off, bid farewell, domination, revenge

--- a/Source/gg2/Objects/Overlays/MedicRadar.events/Draw.xml
+++ b/Source/gg2/Objects/Overlays/MedicRadar.events/Draw.xml
@@ -46,9 +46,9 @@ with(Character) {
                 draw_sprite_ext(MedAlert, (player.team * 10) + player.class + 2, xOffset + width - cos(theta)*38, yOffset+ height/2 -unknown, 1, 1, 0, c_white, bubbleAlpha);
                 draw_set_halign(fa_right);
                 if(theta&lt; pi) {
-                    draw_text(xOffset + width, yOffset+ height/2 -unknown + 20, player.name);
+                    draw_text(xOffset + width, yOffset+ height/2 -unknown + 20, sanitiseNewlines(player.name));
                 } else {
-                    draw_text(xOffset + width, yOffset+ height/2 -unknown - 20, player.name);
+                    draw_text(xOffset + width, yOffset+ height/2 -unknown - 20, sanitiseNewlines(player.name));
                 }
             } else {
                 draw_sprite_ext(MedAlert, bubbleImage == 49, xOffset + width - cos(theta)*38, yOffset+ height/2 -unknown, 1, 1, 0, c_white, bubbleAlpha);
@@ -58,7 +58,7 @@ with(Character) {
             draw_sprite_ext(MedRadarArrow, floor(hp/maxHp * 19), xOffset + unknown+width/2, yOffset+38*sin(theta), 1,1,theta*180/pi, c_white, bubbleAlpha);
             if(mouse_x &gt; xOffset + unknown+width/2 -15&amp;&amp; mouse_x &lt; xOffset + unknown+width/2 + 15 &amp;&amp; mouse_y &lt; yOffset+38*sin(theta) + 15){
                 draw_sprite_ext(MedAlert, (player.team * 10) + player.class + 2, xOffset + unknown+width/2, yOffset+38*sin(theta), 1,1,0, c_white, bubbleAlpha);
-                draw_text(xOffset + unknown+width/2, yOffset+38*sin(theta) + 20, player.name);
+                draw_text(xOffset + unknown+width/2, yOffset+38*sin(theta) + 20, sanitiseNewlines(player.name));
             } else {
                 draw_sprite_ext(MedAlert, bubbleImage == 49, xOffset + unknown+width/2, yOffset+38*sin(theta), 1,1,0, c_white, bubbleAlpha);
             }
@@ -69,9 +69,9 @@ with(Character) {
                 draw_sprite_ext(MedAlert, (player.team * 10) + player.class + 2, xOffset - 38*cos(theta), yOffset + unknown +height/2, 1,1,0, c_white, bubbleAlpha);
                 draw_set_halign(fa_left);
                 if(theta &lt; pi) {
-                    draw_text(xOffset, yOffset + unknown +height/2 +20, player.name);
+                    draw_text(xOffset, yOffset + unknown +height/2 +20, sanitiseNewlines(player.name));
                 } else {
-                    draw_text(xOffset, yOffset + unknown +height/2 -20, player.name);
+                    draw_text(xOffset, yOffset + unknown +height/2 -20, sanitiseNewlines(player.name));
                 }
             } else {
                 draw_sprite_ext(MedAlert, bubbleImage == 49, xOffset - 38*cos(theta), yOffset + unknown +height/2, 1,1,0, c_white, bubbleAlpha);
@@ -81,7 +81,7 @@ with(Character) {
             draw_sprite_ext(MedRadarArrow, floor(hp/maxHp * 19), xOffset +width/2 - unknown, yOffset + height+38*sin(theta), 1,1,theta*180/pi, c_white, bubbleAlpha);
             if(mouse_x &gt; xOffset +width/2 - unknown - 13 &amp;&amp; mouse_x &lt; xOffset +width/2 - unknown + 13 &amp;&amp; mouse_y &gt; yOffset + height+38*sin(theta) - 13){
                 draw_sprite_ext(MedAlert, (player.team * 10) + player.class + 2, xOffset +width/2 - unknown, yOffset + height+38*sin(theta), 1,1,0, c_white, bubbleAlpha);
-                draw_text(xOffset +width/2 - unknown, yOffset + height+38*sin(theta) - 20, player.name);
+                draw_text(xOffset +width/2 - unknown, yOffset + height+38*sin(theta) - 20, sanitiseNewlines(player.name));
             } else {
                 draw_sprite_ext(MedAlert, bubbleImage == 49, xOffset +width/2 - unknown, yOffset + height+38*sin(theta), 1,1,0, c_white, bubbleAlpha);
             }
@@ -89,7 +89,8 @@ with(Character) {
     }
 }
 
-draw_set_alpha(1);</argument>
+draw_set_alpha(1);
+</argument>
       </arguments>
     </action>
   </actions>

--- a/Source/gg2/Objects/Overlays/ScoreTableController.events/Draw.xml
+++ b/Source/gg2/Objects/Overlays/ScoreTableController.events/Draw.xml
@@ -198,8 +198,8 @@
         __x += string_width(__str);
     }
     
-    draw_text(xoffset + 8, yoffset+48, "Server: " + string_copy(global.joinedServerName,1,25));
-    draw_text(xoffset+xsize/2+16, yoffset+48, "    Map: " + string_copy(global.currentMap,1,25));
+    draw_text(xoffset + 8, yoffset+48, "Server: " + sanitiseNewlines(string_copy(global.joinedServerName,1,25)));
+    draw_text(xoffset+xsize/2+16, yoffset+48, "    Map: " + sanitiseNewlines(string_copy(global.currentMap,1,25)));
     
     ds_priority_destroy(redteam);
     ds_priority_destroy(blueteam);

--- a/Source/gg2/Scripts/GameServer/processClientCommands.gml
+++ b/Source/gg2/Scripts/GameServer/processClientCommands.gml
@@ -291,10 +291,6 @@ while(commandLimitRemaining > 0) {
                             break;
                     lastNamechange = current_time;
                     name = read_string(socket, nameLength);
-                    if(string_count("#",name) > 0)
-                    {
-                        name = "I <3 Bacon";
-                    }
                     write_ubyte(global.sendBuffer, PLAYER_CHANGENAME);
                     write_ubyte(global.sendBuffer, playerId);
                     write_ubyte(global.sendBuffer, string_length(name));

--- a/Source/gg2/Scripts/GameServer/serviceJoiningPlayer.gml
+++ b/Source/gg2/Scripts/GameServer/serviceJoiningPlayer.gml
@@ -149,7 +149,6 @@ case STATE_EXPECT_NAME:
     
     player.name = read_string(player.socket, expectedBytes);
     player.name = string_copy(player.name, 0, MAX_PLAYERNAME_LENGTH);
-    player.name = string_replace_all(player.name, "#", " ");
     
     ds_list_add(global.players, player);
     ServerPlayerJoin(player.name, global.sendBuffer);

--- a/Source/gg2/Scripts/Rewards/draw_name_badges.gml
+++ b/Source/gg2/Scripts/Rewards/draw_name_badges.gml
@@ -21,5 +21,5 @@ for (i = 0; i < ds_list_size(player.badges); i += 1)
 }
 
 draw_set_alpha(alpha);
-draw_text(_x, _y, player.name);
+draw_text(_x, _y, sanitiseNewlines(player.name));
 draw_set_alpha(prevalpha);

--- a/Source/gg2/Scripts/_resources.list.xml
+++ b/Source/gg2/Scripts/_resources.list.xml
@@ -57,5 +57,6 @@
   <resource name="draw_pinched_blackrect" type="RESOURCE"/>
   <resource name="createShot" type="RESOURCE"/>
   <resource name="classname" type="RESOURCE"/>
+  <resource name="sanitiseNewlines" type="RESOURCE"/>
   <resource name="Faucet HTTP" type="GROUP"/>
 </resources>

--- a/Source/gg2/Scripts/game_init.gml
+++ b/Source/gg2/Scripts/game_init.gml
@@ -42,7 +42,6 @@
     
     ini_open("gg2.ini");
     global.playerName = ini_read_string("Settings", "PlayerName", "Player");
-    if string_count("#",global.playerName) > 0 global.playerName = "Player";
     global.playerName = string_copy(global.playerName, 0, min(string_length(global.playerName), MAX_PLAYERNAME_LENGTH));
     global.fullscreen = ini_read_real("Settings", "Fullscreen", 0);
     global.useLobbyServer = ini_read_real("Settings", "UseLobby", 1);

--- a/Source/gg2/Scripts/sanitiseNewlines.gml
+++ b/Source/gg2/Scripts/sanitiseNewlines.gml
@@ -1,0 +1,16 @@
+// string sanitiseNewlines(string text)
+// Escapes # and removes chr(10) and chr(13) from text
+// This prevents people from being mischevious and adding newlines to names
+// This should be used when DRAWING text, don't use it to "fix" people's names
+
+var text;
+text = argument0;
+
+// Game Maker displays "#" as a newline, but "\#" as "#"
+text = string_replace_all(text, "#", "\#");
+
+// 0x10 is ASCII Line Feed, 0x13 is ASCII Carriage Return
+text = string_replace_all(text, chr(10), " ");
+text = string_replace_all(text, chr(13), " ");
+
+return text;


### PR DESCRIPTION
This finally cleans up this mess. It removes all the checks for `"#"` we had peppered about the codebase, and removes the inconsistent occasional escaping. In its place, it adds a new `sanitiseNewlines(text)` function, which will replace `"#"` with `"\#"`, and uses it in every single place we draw user input to the screen.

This prevents anyone hacking around the broken old protections again, and means people can use `#` freely in the names of things.

Fixes https://github.com/Gang-Garrison-2/Gang-Garrison-2/issues/127.