### PR TITLE
catch alt f4

### DIFF
--- a/Source/gg2/Objects/InGameElements/PlayerControl.events/Close Button.xml
+++ b/Source/gg2/Objects/InGameElements/PlayerControl.events/Close Button.xml
@@ -13,7 +13,10 @@
       <not>false</not>
       <appliesTo>.self</appliesTo>
       <arguments>
-        <argument kind="STRING">game_end();
+        <argument kind="STRING">if (keyboard_check(vk_alt) or keyboard_check(vk_f4))
+    exit;
+else
+    game_end();
 </argument>
       </arguments>
     </action>


### PR DESCRIPTION
It's pretty common for bad trolls to try and answer every newbie question with
alt f4 in an attempt to close their game so I believe something needs to be
put in place to counter it