### PR TITLE
User configured controls for GB, with alternate control set

### DIFF
--- a/Source/gg2/Objects/InGameElements/Builder.events/Step.xml
+++ b/Source/gg2/Objects/InGameElements/Builder.events/Step.xml
@@ -25,17 +25,17 @@ tooltipIdx = -1;
 
 if (instance_exists(MenuController) || mouse_x &gt; view_xview[0]+view_wview[0] || mouse_x &lt; view_xview[0] || mouse_y &gt; view_yview[0]+view_hview[0] || mouse_y &lt; view_yview[0]) canClick = false;
 else {
-    if (keyboard_check(global.left)) {
+    if (keyboard_check(global.left) || keyboard_check(global.left2)) {
         view_xview[0] -= moveSpeed*global.delta_factor;
         event_user(1);
-    } else if (keyboard_check(global.right)) {
+    } else if (keyboard_check(global.right) || keyboard_check(global.right2)) {
         view_xview[0] += moveSpeed*global.delta_factor;
         event_user(1);
     } 
-    if (keyboard_check(global.jump)) {
+    if (keyboard_check(global.jump) || keyboard_check(global.jump2)) {
         view_yview[0] -= moveSpeed*global.delta_factor;
         event_user(1);
-    } else if (keyboard_check(global.down)) {
+    } else if (keyboard_check(global.down) || keyboard_check(global.down2)) {
         view_yview[0] += moveSpeed*global.delta_factor;
         event_user(1);
     }

--- a/Source/gg2/Objects/InGameElements/Builder.events/Step.xml
+++ b/Source/gg2/Objects/InGameElements/Builder.events/Step.xml
@@ -25,17 +25,17 @@ tooltipIdx = -1;
 
 if (instance_exists(MenuController) || mouse_x &gt; view_xview[0]+view_wview[0] || mouse_x &lt; view_xview[0] || mouse_y &gt; view_yview[0]+view_hview[0] || mouse_y &lt; view_yview[0]) canClick = false;
 else {
-    if (keyboard_check(vk_left)) {
+    if (keyboard_check(global.left)) {
         view_xview[0] -= moveSpeed*global.delta_factor;
         event_user(1);
-    } else if (keyboard_check(vk_right)) {
+    } else if (keyboard_check(global.right)) {
         view_xview[0] += moveSpeed*global.delta_factor;
         event_user(1);
     } 
-    if (keyboard_check(vk_up)) {
+    if (keyboard_check(global.jump)) {
         view_yview[0] -= moveSpeed*global.delta_factor;
         event_user(1);
-    } else if (keyboard_check(vk_down)) {
+    } else if (keyboard_check(global.down)) {
         view_yview[0] += moveSpeed*global.delta_factor;
         event_user(1);
     }

--- a/Source/gg2/Objects/InGameElements/PlayerControl.events/Begin Step.xml
+++ b/Source/gg2/Objects/InGameElements/PlayerControl.events/Begin Step.xml
@@ -55,10 +55,10 @@ if(global.myself.object != -1)
 {
     if(!menuOpen)
     {
-        if(keyboard_check(global.left)) keybyte |= $40;
-        if(keyboard_check(global.right)) keybyte |= $20;
-        if(keyboard_check(global.jump)) keybyte |= $80;
-        if(keyboard_check(global.down)) keybyte |= $02;
+        if(keyboard_check(global.left) || keyboard_check(global.left2)) keybyte |= $40;
+        if(keyboard_check(global.right) || keyboard_check(global.right2)) keybyte |= $20;
+        if(keyboard_check(global.jump) || keyboard_check(global.jump2)) keybyte |= $80;
+        if(keyboard_check(global.down) || keyboard_check(global.down2)) keybyte |= $02;
         if(keyboard_check_pressed(global.medic)) keybyte |= $04;
         if(keyboard_check_pressed(global.chat1)) inputChat1();
         if(keyboard_check_pressed(global.chat2)) inputChat2();
@@ -111,10 +111,10 @@ else if (instance_exists(Spectator))
 }
 
 if(keybyte != 0
-        or keyboard_check(global.left)
-        or keyboard_check(global.right)
-        or keyboard_check(global.jump)
-        or keyboard_check(global.down)) {
+        or keyboard_check(global.left) or keyboard_check(global.left2)
+        or keyboard_check(global.right) or keyboard_check(global.right2)
+        or keyboard_check(global.jump) or keyboard_check(global.jump2)
+        or keyboard_check(global.down) or keyboard_check(global.down2)) {
     afktimer = afktimeout;
 }
 

--- a/Source/gg2/Objects/InGameElements/Spectator.events/End Step.xml
+++ b/Source/gg2/Objects/InGameElements/Spectator.events/End Step.xml
@@ -26,26 +26,26 @@ stopTracking = false;
 //moving view - mapped keys
 if(!instance_exists(MenuController))
 {
-    if keyboard_check(global.left)
+    if keyboard_check(global.left) || keyboard_check(global.left2)
     {
         if (x &gt; view_wview/2)
             x -= 20 * global.delta_factor;
         moved = true;
     }
-    else if keyboard_check(global.right)
+    else if keyboard_check(global.right) || keyboard_check(global.right2)
     {
         if (x &lt; map_width()-view_wview/2)
             x += 20 * global.delta_factor;
         moved = true;
     }
     
-    if keyboard_check(global.jump)
+    if keyboard_check(global.jump) || keyboard_check(global.jump2)
     {
         if (y &gt; view_hview/2)
             y -= 20 * global.delta_factor;
         moved = true;
     }
-    else if keyboard_check(global.down)
+    else if keyboard_check(global.down) || keyboard_check(global.down2)
     {
         if (y &lt; map_height()-view_hview/2)
             y += 20 * global.delta_factor;

--- a/Source/gg2/Objects/Menus/Options Menus/ControlsController.events/Create.xml
+++ b/Source/gg2/Objects/Menus/Options Menus/ControlsController.events/Create.xml
@@ -27,6 +27,10 @@
     menu_addedit_key("Down:", "global.down");
     menu_addedit_key("Left:", "global.left");
     menu_addedit_key("Right:", "global.right");
+    menu_addedit_key("Jump/up (Alternate):", "global.jump2");
+    menu_addedit_key("Down (Alternate):", "global.down2");
+    menu_addedit_key("Left (Alternate):", "global.left2");
+    menu_addedit_key("Right (Alternate):", "global.right2");
     menu_addedit_key("Taunt:", "global.taunt");
     menu_addedit_key("Call for Healer:", "global.medic");
     menu_addedit_key("Drop Case:", "global.drop");

--- a/Source/gg2/Objects/Menus/Options Menus/ControlsController.events/Destroy.xml
+++ b/Source/gg2/Objects/Menus/Options Menus/ControlsController.events/Destroy.xml
@@ -15,9 +15,13 @@
       <arguments>
         <argument kind="STRING">ini_open("controls.gg2");
 ini_write_real("Controls", "jump", global.jump);
+ini_write_real("Controls", "jump alt", global.jump2);
 ini_write_real("Controls", "down", global.down);
+ini_write_real("Controls", "down alt", global.down2);
 ini_write_real("Controls", "left", global.left);
+ini_write_real("Controls", "left alt", global.left2);
 ini_write_real("Controls", "right", global.right);
+ini_write_real("Controls", "right alt", global.right2);
 ini_write_real("Controls", "taunt", global.taunt);
 ini_write_real("Controls", "medic", global.medic);
 ini_write_real("Controls", "drop", global.drop);

--- a/Source/gg2/Scripts/game_init.gml
+++ b/Source/gg2/Scripts/game_init.gml
@@ -443,9 +443,13 @@ global.launchMap = "";
     //Key Mapping
     ini_open("controls.gg2");
     global.jump = ini_read_real("Controls", "jump", ord("W"));
+    global.jump2 = ini_read_real("Controls", "jump alt", vk_up);
     global.down = ini_read_real("Controls", "down", ord("S"));
+    global.down2 = ini_read_real("Controls", "down alt", vk_down);
     global.left = ini_read_real("Controls", "left", ord("A"));
+    global.left2 = ini_read_real("Controls", "left alt", vk_left);
     global.right = ini_read_real("Controls", "right", ord("D"));
+    global.right2 = ini_read_real("Controls", "right alt", vk_right);
     global.attack = ini_read_real("Controls", "attack", MOUSE_LEFT);
     global.special = ini_read_real("Controls", "special", MOUSE_RIGHT);
     global.taunt = ini_read_real("Controls", "taunt", ord("F"));


### PR DESCRIPTION
This extends [arctic's pull request](https://github.com/Medo42/Gang-Garrison-2/pull/268) by adding an alternate Up/Down/Left/Right control set. That way, we can support both WASD and cursor keys in GG2. This doesn't just affect GB, but also gameplay and spectating.
