### PR TITLE
Use default Windows cursor within Garrison Builder

### DIFF
--- a/Source/gg2/Objects/InGameElements/GarrisonBuilderCursorController.events/Create.xml
+++ b/Source/gg2/Objects/InGameElements/GarrisonBuilderCursorController.events/Create.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<event category="CREATE" id="0">
+  <actions>
+    <action id="603" library="1">
+      <!--action name: Code-->
+      <kind>CODE</kind>
+      <allowRelative>false</allowRelative>
+      <question>false</question>
+      <canApplyTo>true</canApplyTo>
+      <actionType>CODE</actionType>
+      <functionName/>
+      <relative>false</relative>
+      <not>false</not>
+      <appliesTo>.self</appliesTo>
+      <arguments>
+        <argument kind="STRING">cursorBackup = window_get_cursor();
+cursorSpriteBackup = cursor_sprite;
+window_set_cursor(cr_default);
+cursor_sprite = -1;
+</argument>
+      </arguments>
+    </action>
+  </actions>
+</event>

--- a/Source/gg2/Objects/InGameElements/GarrisonBuilderCursorController.events/Destroy.xml
+++ b/Source/gg2/Objects/InGameElements/GarrisonBuilderCursorController.events/Destroy.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<event category="DESTROY" id="0">
+  <actions>
+    <action id="603" library="1">
+      <!--action name: Code-->
+      <kind>CODE</kind>
+      <allowRelative>false</allowRelative>
+      <question>false</question>
+      <canApplyTo>true</canApplyTo>
+      <actionType>CODE</actionType>
+      <functionName/>
+      <relative>false</relative>
+      <not>false</not>
+      <appliesTo>.self</appliesTo>
+      <arguments>
+        <argument kind="STRING">window_set_cursor(cursorBackup);
+cursor_sprite = cursorSpriteBackup;
+</argument>
+      </arguments>
+    </action>
+  </actions>
+</event>

--- a/Source/gg2/Objects/InGameElements/GarrisonBuilderCursorController.xml
+++ b/Source/gg2/Objects/InGameElements/GarrisonBuilderCursorController.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<object id="844">
+  <sprite/>
+  <solid>false</solid>
+  <visible>true</visible>
+  <depth>0</depth>
+  <persistent>false</persistent>
+  <parent/>
+  <mask/>
+</object>

--- a/Source/gg2/Objects/InGameElements/_resources.list.xml
+++ b/Source/gg2/Objects/InGameElements/_resources.list.xml
@@ -18,6 +18,7 @@
   <resource name="JoiningPlayer" type="RESOURCE"/>
   <resource name="Balancer" type="RESOURCE"/>
   <resource name="Builder" type="RESOURCE"/>
+  <resource name="GarrisonBuilderCursorController" type="RESOURCE"/>
   <resource name="CollisionDummy" type="RESOURCE"/>
   <resource name="SpriteObject" type="RESOURCE"/>
   <resource name="ParallaxController" type="RESOURCE"/>

--- a/Source/gg2/Rooms/BuilderRoom.xml
+++ b/Source/gg2/Rooms/BuilderRoom.xml
@@ -153,7 +153,14 @@
       <objectFollowing hBorder="32" hSpeed="-1" vBorder="32" vSpeed="-1"/>
     </view>
   </views>
-  <instances/>
+  <instances>
+    <instance>
+      <object>GarrisonBuilderCursorController</object>
+      <position x="0" y="0"/>
+      <creationCode/>
+      <locked>false</locked>
+    </instance>
+  </instances>
   <tiles/>
   <editorSettings remember="false"/>
 </room>


### PR DESCRIPTION
This came out of [the discussion on arctic's extra GB cursors](https://github.com/Medo42/Gang-Garrison-2/pull/263). I think using the Windows cursor within Garrison Builder would be better than the standard GG2 cursor, because it's more suited to precise manipulation.
