### PR TITLE
Fix wrong formula used to calculate seconds in draw_generictimer().

### DIFF
--- a/Source/gg2/Scripts/Macro/draw_generictimer.gml
+++ b/Source/gg2/Scripts/Macro/draw_generictimer.gml
@@ -42,9 +42,9 @@ if (mode == 0)
         {
             draw_sprite_ext(TimerS,floor(countdown/timeLimit*12),xoffset+xsize/2+39,yoffset+30,3,3,0,c_white,1);
             var time, minutes, secondcounter, seconds, secstring;
-            minutes = floor(countdown/1800);
-            secondcounter = countdown-minutes*1800;
-            seconds = ceil(secondcounter/30);
+            secondcounter = ceil(countdown/30);
+            minutes = secondcounter div 60;
+            seconds = secondcounter mod 60;
             
             if (seconds >= 10)
                 secstring = string(seconds);
@@ -70,9 +70,9 @@ else
     {
         draw_set_halign(fa_right);
         var time, minutes, secondcounter, seconds, secstring;
-        minutes = floor(countdown/1800);
-        secondcounter = countdown-minutes*1800;
-        seconds = ceil(secondcounter/30);
+        secondcounter = ceil(countdown/30);
+        minutes = secondcounter div 60;
+        seconds = secondcounter mod 60;
         draw_set_font(global.timerFont);
         
         if (seconds >= 10)


### PR DESCRIPTION
Related to a44e4c7 from PR #294 (yes, it is mine, eh).
This fixes drawing 60 seconds after half of a last second of minute has passed.

![2016-08-18 13-10-25 usa btw i am server ctf_truefort](https://cloud.githubusercontent.com/assets/11665634/17761548/4e483802-654b-11e6-9d8f-ffa16d061354.png)
