### PR TITLE
Correctly show Function keys, Numpad keys, "," "." and "-" in controls menu

### DIFF
--- a/Source/gg2/Objects/Menus/MenuController.events/Draw.xml
+++ b/Source/gg2/Objects/Menus/MenuController.events/Draw.xml
@@ -190,6 +190,10 @@ if(view_hview[0] &lt; 600)
                 else if (gotVar &gt;= 112 &amp;&amp; gotVar &lt;= 123) {
                     val = "F" + string(gotVar - 111);
                 }
+                //Comma, dot, minus
+                else if (gotVar &gt;= 188 &amp;&amp; gotVar &lt;= 190) {
+                    val = gotVar - 144;
+                }
                 else val = chr(menu_get_var(i));
                 break;
             }

--- a/Source/gg2/Objects/Menus/MenuController.events/Draw.xml
+++ b/Source/gg2/Objects/Menus/MenuController.events/Draw.xml
@@ -34,7 +34,7 @@ if(view_hview[0] &lt; 600)
                      *(600-view_hview[0]));
 }
 {
-    var i, val, itemx, itemy, itemcount;
+    var i, val, gotVar, itemx, itemy, itemcount;
     menu_hack_backbutton();
     itemcount = menu_get_itemcount();
     
@@ -189,10 +189,6 @@ if(view_hview[0] &lt; 600)
                 //Function buttons
                 else if (gotVar &gt;= 112 &amp;&amp; gotVar &lt;= 123) {
                     val = "F" + string(gotVar - 111);
-                }
-                //Various
-                else if (gotVar &gt;= 177 &amp;&amp; gotVar &lt;= 191) {
-                    val = chr(gotVar - 144);
                 }
                 else val = chr(menu_get_var(i));
                 break;

--- a/Source/gg2/Objects/Menus/MenuController.events/Draw.xml
+++ b/Source/gg2/Objects/Menus/MenuController.events/Draw.xml
@@ -177,7 +177,24 @@ if(view_hview[0] &lt; 600)
                 val = "Right Mouse Button";
                 break;
             default:
-                val = chr(menu_get_var(i));
+                gotVar = menu_get_var(i);
+                //Numpad number buttons
+                if (gotVar &gt;= 96 &amp;&amp; gotVar &lt;=  105){
+                    val = "NUMPAD " + chr(gotVar - 48);
+                }
+                //Numpad other buttons
+                else if (gotVar &gt;= 106 &amp;&amp; gotVar &lt;=  111){
+                    val = "NUMPAD " + chr(gotVar - 64);
+                }
+                //Function buttons
+                else if (gotVar &gt;= 112 &amp;&amp; gotVar &lt;= 123) {
+                    val = "F" + string(gotVar - 111);
+                }
+                //Various
+                else if (gotVar &gt;= 177 &amp;&amp; gotVar &lt;= 191) {
+                    val = chr(gotVar - 144);
+                }
+                else val = chr(menu_get_var(i));
                 break;
             }
             break;

--- a/Source/gg2/Objects/Menus/MenuController.events/Draw.xml
+++ b/Source/gg2/Objects/Menus/MenuController.events/Draw.xml
@@ -192,7 +192,7 @@ if(view_hview[0] &lt; 600)
                 }
                 //Comma, dot, minus
                 else if (gotVar &gt;= 188 &amp;&amp; gotVar &lt;= 190) {
-                    val = gotVar - 144;
+                    val = chr(gotVar - 144);
                 }
                 else val = chr(menu_get_var(i));
                 break;


### PR DESCRIPTION
Now this is not the perfect fix, but
1. I feel like issue https://github.com/Gang-Garrison-2/Gang-Garrison-2/issues/202 will be quite hard to fix
2. It's still better than adding more switch/case for the Function and numpad keys

With this change the following keys are displayed properly:
- All function keys F1-F12
- All NUMPAD number keys NUMPAD0-NUMPAD9
- All NUMPAD operators  (/ * - + and .). This also means that those keys no longer change based on NumLock status
- Various keys: ! " # $ % & ' ( ) * + , - . /

Note that this changes only what is shown, the game controls and ascii keycodes in controls.gg2 remain the same

I noted that these keys return their Windows Keycode instead of an ascii value. For example when the Windows key [(Windows keycode 93)](https://stackoverflow.com/questions/3360939/what-is-the-ascii-code-of-windows-key) is pressed the menu displays "]" (ascii code 93)
Give [this link](https://help.adobe.com/en_US/AS2LCR/Flash_10.0/help.html?content=00000520.html) a read, even if it's made for ActionScript

I don't think we should close the issue, as a lot of other keys still aren't shown properly (ex. \ ì ò à ù < )